### PR TITLE
Benjisho/add docker compose support 2025 07 14

### DIFF
--- a/example/docker-compose/.env.example
+++ b/example/docker-compose/.env.example
@@ -1,18 +1,64 @@
 # Example environment variables for docker-compose
 # Copy this file to .env and update with your actual values
 
+# === AUTHENTICATION ===
 # Your Tailscale authentication key (required)
 # Get this from https://login.tailscale.com/admin/settings/keys
 TS_AUTHKEY=your_auth_key_here
 
-# Optional: Set hostname for the node
+# Only log in if not already logged in (default: false)
+# TS_AUTH_ONCE=true
+
+# === NETWORKING ===
+# Set hostname for the node
 # TS_HOSTNAME=my-docker-node
 
-# Optional: Advertise subnet routes
+# Advertise subnet routes (comma-separated)
 # TS_ROUTES=192.168.1.0/24,10.0.0.0/8
 
-# Optional: Accept DNS configuration from admin console
+# Proxy all incoming Tailscale traffic to specified destination IP
+# TS_DEST_IP=192.168.1.100
+
+# Accept DNS configuration from admin console (default: false)
 # TS_ACCEPT_DNS=true
 
-# Optional: Additional tailscale up arguments
+# Use userspace networking instead of kernel networking (default: true)
+# Note: We set this to false in docker-compose.yml for better performance
+# TS_USERSPACE=false
+
+# === STATE AND STORAGE ===
+# Directory where tailscaled state is stored (default: /var/lib/tailscale)
+# TS_STATE_DIR=/var/lib/tailscale
+
+# Unix socket path for LocalAPI (default: /var/run/tailscale/tailscaled.sock)
+# TS_SOCKET=/var/run/tailscale/tailscaled.sock
+
+# === HEALTH AND METRICS (Tailscale 1.78+) ===
+# Enable unauthenticated /healthz endpoint (default: false)
+# TS_ENABLE_HEALTH_CHECK=true
+
+# Enable unauthenticated /metrics endpoint (default: false)
+# TS_ENABLE_METRICS=true
+
+# Address/port for health/metrics endpoints (default: [::]:9002)
+# TS_LOCAL_ADDR_PORT=:9002
+
+# === PROXY CONFIGURATION ===
+# Set SOCKS5 proxy address/port
+# TS_SOCKS5_SERVER=:1055
+
+# Set HTTP proxy address/port
+# TS_OUTBOUND_HTTP_PROXY_LISTEN=:8080
+
+# === ADVANCED CONFIGURATION ===
+# JSON file path for Serve/Funnel configuration
+# TS_SERVE_CONFIG=/path/to/serve-config.json
+
+# Kubernetes secret name for state storage (default: tailscale)
+# TS_KUBE_SECRET=tailscale
+
+# Additional flags for tailscale up command
 # TS_EXTRA_ARGS=--accept-routes --ssh
+
+# Additional flags for tailscaled daemon
+# TS_TAILSCALED_EXTRA_ARGS=--verbose=2

--- a/example/docker-compose/.env.example
+++ b/example/docker-compose/.env.example
@@ -1,0 +1,18 @@
+# Example environment variables for docker-compose
+# Copy this file to .env and update with your actual values
+
+# Your Tailscale authentication key (required)
+# Get this from https://login.tailscale.com/admin/settings/keys
+TS_AUTHKEY=your_auth_key_here
+
+# Optional: Set hostname for the node
+# TS_HOSTNAME=my-docker-node
+
+# Optional: Advertise subnet routes
+# TS_ROUTES=192.168.1.0/24,10.0.0.0/8
+
+# Optional: Accept DNS configuration from admin console
+# TS_ACCEPT_DNS=true
+
+# Optional: Additional tailscale up arguments
+# TS_EXTRA_ARGS=--accept-routes --ssh

--- a/example/docker-compose/.env.example
+++ b/example/docker-compose/.env.example
@@ -58,7 +58,11 @@ TS_AUTHKEY=your_auth_key_here
 # TS_KUBE_SECRET=tailscale
 
 # Additional flags for tailscale up command
+# Common examples:
 # TS_EXTRA_ARGS=--accept-routes --ssh
+# TS_EXTRA_ARGS=--advertise-tags=tag:container
+# TS_EXTRA_ARGS=--accept-routes --advertise-tags=tag:docker
+TS_EXTRA_ARGS=
 
 # Additional flags for tailscaled daemon
 # TS_TAILSCALED_EXTRA_ARGS=--verbose=2

--- a/example/docker-compose/.gitignore
+++ b/example/docker-compose/.gitignore
@@ -1,0 +1,5 @@
+# Environment file with secrets
+.env
+
+# Tailscale state directory
+tailscale-state/

--- a/example/docker-compose/README.md
+++ b/example/docker-compose/README.md
@@ -1,15 +1,33 @@
 # Docker Compose Example
 
 This directory provides a minimal `docker-compose.yml` file that runs
-the Tailscale daemon in a container. Supply your authentication key via
-the `TS_AUTHKEY` environment variable. The container uses host
-networking, requires the TUN device and runs in privileged mode.
+the Tailscale daemon in a container following the official Tailscale Docker
+documentation at https://tailscale.com/kb/1282/docker.
 
-Start the containers with:
+## Setup
 
-```bash
-docker compose up -d
-```
+1. Copy the example environment file:
+   ```bash
+   cp .env.example .env
+   ```
 
-Once running, the container joins your tailnet and persists its state in
-`./tailscale-state`.
+2. Edit `.env` and set your Tailscale authentication key:
+   ```bash
+   TS_AUTHKEY=your_auth_key_here
+   ```
+   Get your auth key from https://login.tailscale.com/admin/settings/keys
+
+3. Start the container:
+   ```bash
+   docker compose up -d
+   ```
+
+## Configuration
+
+The container uses:
+- Host networking (`network_mode: host`)
+- Kernel networking (`TS_USERSPACE=false`) with TUN device access
+- `net_admin` capability for network configuration
+- Persistent state storage in `./tailscale-state`
+
+Once running, the container joins your tailnet and persists its state.

--- a/example/docker-compose/README.md
+++ b/example/docker-compose/README.md
@@ -1,0 +1,15 @@
+# Docker Compose Example
+
+This directory provides a minimal `docker-compose.yml` file that runs
+the Tailscale daemon in a container. Supply your authentication key via
+the `TS_AUTHKEY` environment variable. The container uses host
+networking, requires the TUN device and runs in privileged mode.
+
+Start the containers with:
+
+```bash
+docker compose up -d
+```
+
+Once running, the container joins your tailnet and persists its state in
+`./tailscale-state`.

--- a/example/docker-compose/README.md
+++ b/example/docker-compose/README.md
@@ -31,3 +31,59 @@ The container uses:
 - Persistent state storage in `./tailscale-state`
 
 Once running, the container joins your tailnet and persists its state.
+
+## Environment Variables
+
+All configuration is optional. You can set additional parameters in your `.env` file:
+
+### Authentication
+- **`TS_AUTHKEY`** - Auth key used to authenticate the container. Get from https://login.tailscale.com/admin/settings/keys
+  - Can also use OAuth client secret (requires `TS_EXTRA_ARGS=--advertise-tags=tag:ci`)
+  - Append `?ephemeral=true` to mark node as ephemeral
+- **`TS_AUTH_ONCE`** - Only log in if not already logged in (default: false)
+
+### Networking
+- **`TS_HOSTNAME`** - Set hostname for the node
+- **`TS_ROUTES`** - Advertise subnet routes (e.g., `192.168.1.0/24,10.0.0.0/8`)
+- **`TS_DEST_IP`** - Proxy all incoming Tailscale traffic to specified destination IP
+- **`TS_ACCEPT_DNS`** - Accept DNS configuration from admin console (default: false)
+- **`TS_USERSPACE`** - Enable userspace networking instead of kernel networking (default: true)
+
+### State and Storage
+- **`TS_STATE_DIR`** - Directory where tailscaled state is stored (default: `/var/lib/tailscale`)
+- **`TS_SOCKET`** - Unix socket path for LocalAPI (default: `/var/run/tailscale/tailscaled.sock`)
+
+### Health and Metrics (Tailscale 1.78+)
+- **`TS_ENABLE_HEALTH_CHECK`** - Enable `/healthz` endpoint (default: false)
+- **`TS_ENABLE_METRICS`** - Enable `/metrics` endpoint (default: false)
+- **`TS_LOCAL_ADDR_PORT`** - Address/port for health/metrics endpoints (default: `[::]:9002`)
+- **`TS_HEALTHCHECK_ADDR_PORT`** - ⚠️ Deprecated, use `TS_ENABLE_HEALTH_CHECK` instead
+
+### Proxy Configuration
+- **`TS_SOCKS5_SERVER`** - Set SOCKS5 proxy address/port (e.g., `:1055`)
+- **`TS_OUTBOUND_HTTP_PROXY_LISTEN`** - Set HTTP proxy address/port
+
+### Advanced Configuration
+- **`TS_SERVE_CONFIG`** - JSON file path for Serve/Funnel configuration
+- **`TS_KUBE_SECRET`** - Kubernetes secret name for state storage (default: `tailscale`)
+- **`TS_EXTRA_ARGS`** - Additional flags for `tailscale up` command
+- **`TS_TAILSCALED_EXTRA_ARGS`** - Additional flags for `tailscaled` daemon
+
+### Example Configuration
+```bash
+# Basic setup
+TS_AUTHKEY=tskey-auth-your-key-here
+TS_HOSTNAME=my-docker-node
+
+# Subnet routing
+TS_ROUTES=192.168.1.0/24,10.0.0.0/8
+TS_EXTRA_ARGS=--accept-routes --ssh
+
+# Health monitoring
+TS_ENABLE_HEALTH_CHECK=true
+TS_ENABLE_METRICS=true
+TS_LOCAL_ADDR_PORT=:9002
+
+# DNS configuration
+TS_ACCEPT_DNS=true
+```

--- a/example/docker-compose/docker-compose.yml
+++ b/example/docker-compose/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   tailscaled:
     image: tailscale/tailscale:latest
     container_name: tailscaled
+    hostname: tailscaled
     network_mode: host
     restart: unless-stopped
     volumes:
@@ -15,3 +16,4 @@ services:
       - TS_AUTHKEY=${TS_AUTHKEY}
       - TS_STATE_DIR=/var/lib/tailscale
       - TS_USERSPACE=false
+      - TS_EXTRA_ARGS=${TS_EXTRA_ARGS:-}

--- a/example/docker-compose/docker-compose.yml
+++ b/example/docker-compose/docker-compose.yml
@@ -1,15 +1,17 @@
 ---
-version: '3.8'
 services:
   tailscaled:
     image: tailscale/tailscale:latest
     container_name: tailscaled
     network_mode: host
-    privileged: true
     restart: unless-stopped
     volumes:
-      - ./tailscale-state:/var/lib
+      - ./tailscale-state:/var/lib/tailscale
+    devices:
       - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - net_admin
     environment:
       - TS_AUTHKEY=${TS_AUTHKEY}
-    command: tailscaled
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_USERSPACE=false

--- a/example/docker-compose/docker-compose.yml
+++ b/example/docker-compose/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+version: '3.8'
+services:
+  tailscaled:
+    image: tailscale/tailscale:latest
+    container_name: tailscaled
+    network_mode: host
+    privileged: true
+    restart: unless-stopped
+    volumes:
+      - ./tailscale-state:/var/lib
+      - /dev/net/tun:/dev/net/tun
+    environment:
+      - TS_AUTHKEY=${TS_AUTHKEY}
+    command: tailscaled


### PR DESCRIPTION
This pull request introduces a complete example for running Tailscale using Docker Compose. It includes configuration files, documentation, and a sample `docker-compose.yml` setup to simplify deployment. The changes are grouped into the following themes:

### Configuration and Setup Files
* Added `example/docker-compose/.env.example` with detailed example environment variables for configuring Tailscale in Docker Compose. This includes settings for authentication, networking, state storage, health checks, and advanced configurations.
* Updated `example/docker-compose/.gitignore` to exclude `.env` files and the `tailscale-state` directory, ensuring sensitive information and state data are not accidentally committed.

### Documentation
* Added `example/docker-compose/README.md` with comprehensive instructions for setting up and configuring Tailscale in Docker Compose. It includes environment variable descriptions, example configurations, and advanced usage patterns like the sidecar container setup.

### Docker Compose Configuration
* Created `example/docker-compose/docker-compose.yml` to define a minimal Docker Compose setup for running the Tailscale daemon. It uses host networking, kernel-based networking, and persistent state storage.